### PR TITLE
Fix manifest key order for hassfest compliance

### DIFF
--- a/custom_components/petsafe/manifest.json
+++ b/custom_components/petsafe/manifest.json
@@ -1,19 +1,19 @@
 {
-  "version": "1.4.0",
   "domain": "petsafe",
   "name": "PetSafe",
-  "config_flow": true,
-  "documentation": "https://github.com/dcmeglio/homeassistant-petsafe/blob/master/README",
-  "requirements": [
-    "petsafe==2.0.6"
-  ],
-  "issue_tracker": "https://github.com/dcmeglio/homeassistant-petsafe/issues",
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": [
     "@dcmeglio"
   ],
-  "iot_class": "cloud_polling"
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/dcmeglio/homeassistant-petsafe/blob/master/README",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/dcmeglio/homeassistant-petsafe/issues",
+  "requirements": [
+    "petsafe==2.0.6"
+  ],
+  "ssdp": [],
+  "version": "1.4.0",
+  "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- reorder the PetSafe manifest keys so `domain` and `name` lead and the remainder are alphabetical to satisfy hassfest validation

## Testing
- python script/hassfest --integration-path custom_components/petsafe


------
https://chatgpt.com/codex/tasks/task_e_68dafae556308326a243b03f3733d878