### PR TITLE
Show smartdoor friendly names in config flow

### DIFF
--- a/custom_components/petsafe/config_flow.py
+++ b/custom_components/petsafe/config_flow.py
@@ -137,7 +137,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._litterboxes = {
             x.api_name: x.friendly_name for x in await self._client.get_litterboxes()
         }
+        smartdoors = await self._client.get_smartdoors()
         self._smartdoors = {
-            x.api_name: x.friendly_name for x in await self._client.get_smartdoors()
+            door.api_name: (
+                getattr(door, "friendly_name", None)
+                or getattr(door, "data", {}).get("friendlyName")
+                or door.api_name
+            )
+            for door in smartdoors
         }
         return True


### PR DESCRIPTION
## Summary
- ensure the smartdoor selector in the config flow resolves friendly names instead of API IDs

## Testing
- isort .
- ruff format
- ruff check *(fails: existing lint violations in unrelated modules)*
- python -m flake8 custom_components/petsafe tests *(fails: existing lint violations in unrelated modules)*
- python -m pylint custom_components/petsafe tests *(fails: existing lint violations in unrelated modules)*
- python script/hassfest --integration-path custom_components/petsafe
- pytest ./tests --cov=custom_components.petsafe --cov-report term-missing


------
https://chatgpt.com/codex/tasks/task_e_68ffe8d625288326aacee6b7782b827e