### PR TITLE
Use smart door friendly names during config flow selection

### DIFF
--- a/custom_components/petsafe/config_flow.py
+++ b/custom_components/petsafe/config_flow.py
@@ -138,6 +138,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             x.api_name: x.friendly_name for x in await self._client.get_litterboxes()
         }
         self._smartdoors = {
-            x.api_name: x.friendly_name for x in await self._client.get_smartdoors()
+            x.api_name: (
+                x.data.get("friendlyName")
+                if hasattr(x, "data") and isinstance(getattr(x, "data"), dict)
+                else None
+            )
+            or x.friendly_name
+            or x.api_name
+            for x in await self._client.get_smartdoors()
         }
         return True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,61 @@
+"""Tests for the PetSafe config flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.petsafe.config_flow import ConfigFlow
+
+
+class _StubDevice:
+    """Represent a minimal PetSafe device for config flow tests."""
+
+    def __init__(self, api_name: str, friendly_name: str | None = None, data=None) -> None:
+        self.api_name = api_name
+        self.friendly_name = friendly_name
+        self.data = data or {}
+
+
+class _StubClient:
+    """Stub PetSafe client to validate device collection."""
+
+    def __init__(self) -> None:
+        self.id_token = "id"
+        self.access_token = "access"
+        self.refresh_token = "refresh"
+
+    async def request_tokens_from_code(self, code: str) -> None:  # pragma: no cover - trivial
+        return None
+
+    async def get_feeders(self) -> list[_StubDevice]:  # pragma: no cover - config flow only
+        return []
+
+    async def get_litterboxes(self) -> list[_StubDevice]:  # pragma: no cover - config flow only
+        return []
+
+    async def get_smartdoors(self) -> list[_StubDevice]:
+        return [
+            _StubDevice(
+                api_name="door-id-1",
+                friendly_name="API Friendly",
+                data={"friendlyName": "Custom Friendly"},
+            ),
+            _StubDevice(api_name="door-id-2", friendly_name="Fallback Friendly"),
+            _StubDevice(api_name="door-id-3"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_get_devices_uses_smartdoor_friendly_name() -> None:
+    """The config flow should expose friendly names for smart doors."""
+
+    flow = ConfigFlow()
+    flow._client = _StubClient()  # noqa: SLF001 - direct assignment for test
+
+    await flow.get_devices("user@example.com", "123456")
+
+    assert flow._smartdoors == {
+        "door-id-1": "Custom Friendly",
+        "door-id-2": "Fallback Friendly",
+        "door-id-3": "door-id-3",
+    }


### PR DESCRIPTION
## Summary
- prefer the PetSafe smart door friendly name when presenting devices in the config flow
- cover the smart door name selection logic with a focused config flow test

## Testing
- pytest tests/test_config_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68ffe8d625288326aacee6b7782b827e