### PR TITLE
Add SmartDoor friendly name and timezone attributes

### DIFF
--- a/custom_components/petsafe/SmartDoorEntities.py
+++ b/custom_components/petsafe/SmartDoorEntities.py
@@ -47,6 +47,7 @@ class PetSafeSmartDoorLockEntity(CoordinatorEntity[PetSafeData], LockEntity):
         friendly_name = (
             getattr(device, "friendly_name", None)
             or device.data.get("friendlyName")
+            or device.data.get("friendly_name")
             or device.api_name
         )
 
@@ -65,7 +66,11 @@ class PetSafeSmartDoorLockEntity(CoordinatorEntity[PetSafeData], LockEntity):
             return {}
 
         data = door.data if isinstance(door.data, Mapping) else {}
-        friendly_name = getattr(door, "friendly_name", None) or data.get("friendlyName")
+        friendly_name = (
+            getattr(door, "friendly_name", None)
+            or data.get("friendlyName")
+            or data.get("friendly_name")
+        )
         timezone = getattr(door, "timezone", None) or data.get("timezone")
 
         attributes = {
@@ -80,7 +85,7 @@ class PetSafeSmartDoorLockEntity(CoordinatorEntity[PetSafeData], LockEntity):
         }
 
         if friendly_name is not None:
-            attributes["friendlyName"] = friendly_name
+            attributes["friendly_name"] = friendly_name
         if timezone is not None:
             attributes["timezone"] = timezone
 

--- a/tests/test_smartdoor.py
+++ b/tests/test_smartdoor.py
@@ -92,7 +92,7 @@ async def test_lock_entity_state_and_controls(hass, coordinator) -> None:
         "battery_voltage": 12.3,
         "rssi": -40,
         "battery_level": 75,
-        "friendlyName": "Back Door",
+        "friendly_name": "Back Door",
         "timezone": "America/Chicago",
     }
     for key, value in expected_attrs.items():


### PR DESCRIPTION
## Summary
- expose the PetSafe SmartDoor friendlyName and timezone as lock attributes
- update SmartDoor tests to cover the new metadata

## Testing
- pytest tests/test_smartdoor.py

------
https://chatgpt.com/codex/tasks/task_e_69000317e2a48326b813f5d00463508b